### PR TITLE
fix #3

### DIFF
--- a/_episodes/06-dockerfiles.md
+++ b/_episodes/06-dockerfiles.md
@@ -13,6 +13,7 @@ keypoints:
 - "Images are built with `podman build`"
 - "Images can have multiple tags associated to them"
 - "Images can use `COPY` to copy files into them during build"
+- "Images can use `ADD` to copy remote files and extract compressed files"
 ---
 <iframe width="427" height="251" src="https://www.youtube.com/embed/NSVXBgYSkBY?si=pAZsMxfkZ2imcL52" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -279,6 +280,23 @@ For very complex scripts or files that are on some remote, `COPY` offers a strai
 way to bring them into the container image build.
 
 
+## `ADD`
+
+The `ADD` command is very similar to the `COPY` command, except that the `ADD` command supports two additional features:
+1. Automatic de-compression of compressed files.
+2. Automatic fetching of remote URLs (starting with `http://` or `https://`) and cloning of git repositories (starting with `git@`).
+
+When these features are not required, [`COPY` is preferred][add-or-copy].
+
+Note that
+- local compressed files are unpacked by default
+- remote compressed files are not unpacking by default
+
+This behaviour can be changed by adding a `--unpack=true` or `--unpack=false` flag immediately after the `ADD` command.
+```yaml
+ADD --unpack=true <src> <dest>
+```
+{: .source}
 [docker-docs-builder]: https://docs.docker.com/engine/reference/builder/
 [example-Dockerfile]: https://github.com/matthewfeickert/intro-to-docker/blob/feat/update-2021-bootcamp/docker/Dockerfile
 [python-docker-image]: https://hub.docker.com/_/python
@@ -287,5 +305,6 @@ way to bring them into the container image build.
 [podman-docs-build]: https://docs.podman.io/en/stable/markdown/podman-build.1.html
 [podman-docs-tag]: https://docs.podman.io/en/latest/markdown/podman-tag.1.html
 [docker-docs-COPY]: https://docs.docker.com/engine/reference/builder/#copy
+[add-or-copy]: https://docs.docker.com/build/building/best-practices/#add-or-copy
 
 {% include links.md %}


### PR DESCRIPTION
Explain Dockerfile `ADD` command, and how it differs from `COPY`.

I haven't yet added a full example Dockerfile making use of the features of the `ADD` command. I'm hoping that this short description is enough to familiarize the reader in case they encounter the command in the wild, without making it too repetitive of the previous section on the `COPY` command. I also avoided giving a complete example so that we don't depend on a remote URL to fetch from.

I could still add one, but I'm hoping that this covers the most important concepts.